### PR TITLE
remove broken skills link

### DIFF
--- a/pages/skills.mdx
+++ b/pages/skills.mdx
@@ -20,4 +20,4 @@ Currently you can define English rules to control MultiOn Behavior on specific w
 
 Unleash your creativity with MULTION Skills! 🌟
 
-Learn more on our [GitHub page](https://github.com/MULTI-ON/skills).
+


### PR DESCRIPTION
The link was redirecting to nowhere because the page does not exist yet. We should remove this line until we have a Skills page to link here. 